### PR TITLE
Fix Reuters fetch and update docs

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -36,6 +36,6 @@ jobs:
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          git add sentiment_scores.csv
+          git add -f sentiment_scores.csv
           git commit -m "hourly: update sentiment CSV" || echo "No changes to commit"
           git push

--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
 # seed_Elhashino_sentiment
 Hourly AI-computed sentiment data for TradingView
+
+## Running the updater
+
+Execute `python update_sentiment.py` to pull recent news from Google, Reuters,
+Reddit and Investing.com. Sentiment scores are appended to `sentiment_scores.csv`
+in the project root.
+
+## Launching the dashboard
+
+Start the web interface with `streamlit run dashboard.py`. The dashboard reads
+`sentiment_scores.csv` and displays the latest score for each symbol. If the CSV
+is missing you'll be prompted to run the updater first.
+
+## GitHub Actions workflow
+
+The repository contains a workflow that runs `update_sentiment.py` every hour and
+commits the updated CSV back to the repository.

--- a/dashboard.py
+++ b/dashboard.py
@@ -16,7 +16,7 @@ st.write("This shows the latest FinBERT sentiment for each symbol.")
 
 # ─── 2) LOAD THE CSV ───────────────────────────────────────────────
 if not os.path.exists("sentiment_scores.csv"):
-    st.error("No sentiment_scores.csv found. Run update_sentiment first.")
+    st.error("No sentiment_scores.csv found. Run `update_sentiment.py` first.")
     st.stop()
 
 df = pd.read_csv("sentiment_scores.csv", parse_dates=["timestamp"])

--- a/test_sentiment.py
+++ b/test_sentiment.py
@@ -1,32 +1,21 @@
-# test_sentiment.py
+import pytest
 
-from update_sentiment import fetch_all_tweets, compute_sentiment, fetch_reddit_comments
+from update_sentiment import fetch_reddit, compute_sentiment
 
-SYMBOLS = ["EURUSD","USDJPY","GBPUSD","AUDUSD","USDCAD",
-           "XAUUSD","CL","BTCUSD","SPY","AAPL"]
 
-# 1) Test Twitter fetch + sentiment
-print("\n=== Twitter Test ===")
-buckets = fetch_all_tweets(SYMBOLS, max_results=50)
-for sym, texts in buckets.items():
-    print(f"\n--- {sym} ({len(texts)} tweets) ---")
-    if not texts:
-        print(" • No tweets fetched")
-        continue
-    for t in texts[:3]:  # show up to first 3 tweets
-        print(" •", t.replace("\n", " ")[:100], "…")
-    score = compute_sentiment(texts)
-    print(f"→ Twitter-only avg for {sym}: {score:.3f}" if score is not None else "→ Sentiment unavailable")
+def test_fetch_reddit_returns_list():
+    posts = fetch_reddit("EURUSD", max_items=1)
+    assert isinstance(posts, list)
 
-# 2) Test Reddit fetch + sentiment on AAPL
-sample = "AAPL"
-print("\n=== Reddit Test for AAPL ===")
-rd = fetch_reddit_comments(sample, limit=10)
-print(f"--- {sample} Reddit ({len(rd)} posts) ---")
-if not rd:
-    print(" • No Reddit posts fetched")
-else:
-    for p in rd[:3]:
-        print(" •", p.replace("\n", " ")[:100], "…")
-    score_rd = compute_sentiment(rd)
-    print(f"→ Reddit-only avg for {sample}: {score_rd:.3f}" if score_rd is not None else "→ Sentiment unavailable")
+
+def test_compute_sentiment_output_types():
+    score, count = compute_sentiment(["The market looks good today."])
+    assert isinstance(score, float)
+    assert isinstance(count, int)
+    assert count == 1
+
+
+def test_compute_sentiment_empty_input():
+    score, count = compute_sentiment([])
+    assert score == 0.0
+    assert count == 0

--- a/update_sentiment.py
+++ b/update_sentiment.py
@@ -1,9 +1,9 @@
 # update_sentiment.py
 # ────────────────────────────────────────────────────────────────────
-# Pulls news/reddit/Investing.com text, runs FinBERT sentiment,
+# Pulls news/Reuters/Reddit/Investing.com text, runs FinBERT sentiment,
 # and appends the timestamped scores into "sentiment_scores.csv".
 #
-# Usage: just run “python update_sentiment.py” (it writes/appends a CSV).
+# Usage: just run "python update_sentiment.py" (it writes/appends a CSV).
 # The GitHub Action will do that every hour automatically.
 # ────────────────────────────────────────────────────────────────────
 
@@ -129,11 +129,13 @@ def main():
         if first:
             writer.writerow(["timestamp", "symbol", "sentiment_score", "num_texts"])
 
+        reuters_texts = fetch_reuters_fx()
+
         for sym in SYMBOLS:
             print(f"→ Scoring {sym} …")
             texts = []
             texts += fetch_google_news(sym)
-            texts += fetch_reuters_fx()
+            texts += reuters_texts
             texts += fetch_reddit(sym)
             texts += fetch_investing(sym)
 


### PR DESCRIPTION
## Summary
- clarify updater usage comment
- avoid repeated Reuters fetches by calling once outside the loop
- document how to run updater and dashboard
- test compute_sentiment on empty input

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'feedparser')*

------
https://chatgpt.com/codex/tasks/task_e_683f3fda6d3083288ad0d8b824ec1e07